### PR TITLE
Fix broadcast colors

### DIFF
--- a/mods/Fifty.ServerMessages/mod/scripts/vscripts/fsm_core.nut
+++ b/mods/Fifty.ServerMessages/mod/scripts/vscripts/fsm_core.nut
@@ -105,7 +105,7 @@ void function FSM_BroadcastMessages_Threaded() {
 	array< string > messages
 
 	for( int i = 0; i < 5; i++ ) {
-		messages.append( FSU_GetFormattedConVar( "FSM_BROADCAST_" + i ) )
+		messages.append( GetConVarString( "FSM_BROADCAST_" + i ) )
 	}
 
 
@@ -151,8 +151,8 @@ void function FSM_PrintWelcomeMessage( entity player ) {
 	if( GetConVarBool( "FSM_WELCOME_USE_RUI" ) ) {
 		NSSendLargeMessageToPlayer( player, GetConVarString( "FSM_WELCOME_MESSAGE_TITLE" ), GetConVarString( "FSM_WELCOME_MESSAGE_TEXT" ), 20, GetConVarString( "FSM_WELCOME_MESSAGE_IMAGE" ) )
 	} else {
-		FSU_ChatBroadcast( FSU_GetFormattedConVar( "FSM_WELCOME_MESSAGE_TITLE" ) )
-		FSU_ChatBroadcast( FSU_GetFormattedConVar( "FSM_WELCOME_MESSAGE_TEXT" ) )
+		FSU_PrivateChatMessage( player, "%N" + GetConVarString( "FSM_WELCOME_MESSAGE_TITLE" ) )
+		FSU_PrivateChatMessage( player, "%N" + GetConVarString( "FSM_WELCOME_MESSAGE_TEXT" ) )
 	}
 }
 #else

--- a/mods/Fifty.ServerUtilities/mod/scripts/vscripts/fsu_core.nut
+++ b/mods/Fifty.ServerUtilities/mod/scripts/vscripts/fsu_core.nut
@@ -295,15 +295,6 @@ int function FSU_GetIntegerFromHexString( string hex ) {
 }
 
 /**
- * Returns a formatted string convar
- * @param convar The convar to format
-*/
-string function FSU_GetFormattedConVar( string convar ) {
-	string formatted = FSU_FormatString( GetConVarString( convar ) )
-	return formatted
-}
-
-/**
  * Highlights a string using ANSI code and returns the highlited string
  * @param mesage The string to be highlited
 */


### PR DESCRIPTION
Deleted FSU_GetFormattedConVar.

It is redundant, as FSU_ChatBroadcast already passes everything through FSU_FormatString.

In fact due to this double formatting, the color formatting for any text passed through it is currently broken.