### PR TITLE
Fix kick command printing the wrong username in chat

### DIFF
--- a/mods/Fifty.ServerVote/mod/scripts/vscripts/fsv_command_callbacks.nut
+++ b/mods/Fifty.ServerVote/mod/scripts/vscripts/fsv_command_callbacks.nut
@@ -419,7 +419,7 @@ void function FSV_CommandCallback_Kick( entity player, array<string> args) {
 
 		FSU_Print( targetName + " kicked by admin:" + player.GetPlayerName())
 		ServerCommand("kick " + target.GetPlayerName())
-		FSU_ChatBroadcast("%H"+player.GetPlayerName() + " %Nwas kicked by an admin.")
+		FSU_ChatBroadcast("%H"+targetName + " %Nwas kicked by an admin.")
 		return
 	}
 


### PR DESCRIPTION
Apparently after using the kick command to kick a cheater, an admin had `[admin's username] was kicked by an admin` print out in chat instead of `[cheater's username] was kicked by an admin`

This should fix the issue

Untested, but it's one line...